### PR TITLE
feat: 웹툰 상세 페이지 구현

### DIFF
--- a/src/component/forWebtoon/forToonView/episodeList.jsx
+++ b/src/component/forWebtoon/forToonView/episodeList.jsx
@@ -1,0 +1,53 @@
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+import styled from 'styled-components';
+
+const EpisodeList = () => {
+    const rowData = [
+        {'등록 날짜': '2023-02-10', '제목': 'episode1', '파일': ''},
+        {'등록 날짜': '2023-03-10', '제목': 'episode2', '파일': ''},
+        {'등록 날짜': '2023-04-10', '제목': 'episode3', '파일': ''},
+    ];
+
+    const columnDefs = [
+        {field: '등록 날짜', sortable: true, filter: true},
+        {field: '제목', filter: true},
+        {field: '파일'},
+    ];
+
+    const titleText = `회차 (${rowData.length}개)`;
+
+    return(
+        <EpisodeListContainer>
+            <Title>{titleText}</Title>
+            <EpisodeListGrid className="ag-theme-alpine">
+                <AgGridReact 
+                    rowData={rowData}
+                    columnDefs={columnDefs}
+                    animateRows={true}
+                    rowSelection='multiple'
+                    domLayout= 'autoHeight'
+                />
+            </EpisodeListGrid>
+        </EpisodeListContainer>
+    );
+};
+export default EpisodeList;
+
+const EpisodeListContainer = styled.div`
+    margin-top: 50px;
+    padding: 10px 10px 10px 25px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+`;
+
+const Title = styled.h3`
+    margin-left: 10px;
+`;
+
+const EpisodeListGrid = styled.div`
+    width: 610px;
+    height: auto;
+    overflow: hidden;
+`

--- a/src/component/forWebtoon/forToonView/textAndBtnArea.jsx
+++ b/src/component/forWebtoon/forToonView/textAndBtnArea.jsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import theme from './../../../style/theme';
+
+const TextAndBtnArea = () => {
+    return(
+        <TextAndBtnContainer>
+            <Title>웹툰 상세</Title>
+            <BtnContainer>
+                <Btn>수 정</Btn>
+                <Btn>삭 제</Btn>
+            </BtnContainer>
+        </TextAndBtnContainer>
+    );
+};
+export default TextAndBtnArea;
+
+const TextAndBtnContainer = styled.div`
+    display: flex;
+`;
+
+const Title = styled.div`
+    font-size: 30px;
+    font-weight: bold;
+`;
+
+const BtnContainer = styled.div`
+    display: flex;
+    margin-left: 600px;
+    align-items: center;
+`;
+
+const Btn = styled.button`
+    width: 90px;
+    height: 40px;
+    background-color: ${theme.colors.btn};
+    border: none;
+    color: ${theme.colors.white};
+    text-align: center;
+    border-radius: 8px;
+    box-shadow: 0 5px 10px rgba(0,0,0,0.10), 0 2px 2px rgba(0,0,0,0.20);
+    &:hover {
+        background-color: #00B757;
+    }
+    cursor: pointer;
+    margin: 0px 15px 0px 15px;
+`

--- a/src/component/forWebtoon/forToonView/toonContent.jsx
+++ b/src/component/forWebtoon/forToonView/toonContent.jsx
@@ -1,0 +1,74 @@
+import styled from 'styled-components';
+import theme from '../../../style/theme';
+
+const FakeWebtoonData = [
+    {
+        id: 1,
+        imageUrl: 'https://image.newdaily.co.kr/site/data/img/2023/05/30/2023053000065_0.png',
+        name: 'toon1',
+        week: '월요일',
+        keyword: '로맨스',
+        author: 'author1',
+        expla: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    },
+];
+
+const ToonContent = () => {
+    return(
+        <ToonContentContainer>
+                    <ToonImgContainer>
+                        <Img src={FakeWebtoonData[0].imageUrl} alt={`${FakeWebtoonData[0].name}의 썸네일`} />
+                    </ToonImgContainer>
+                    <ToonInfoContainer>
+                        <ToonInfoBox>제목 <ToonInfoData>{FakeWebtoonData[0].name}</ToonInfoData></ToonInfoBox>
+                        <ToonInfoBox>업로드 요일 <ToonInfoData>{FakeWebtoonData[0].week}</ToonInfoData></ToonInfoBox>
+                        <ToonInfoBox>키워드 <ToonInfoData>{FakeWebtoonData[0].keyword}</ToonInfoData></ToonInfoBox>
+                        <ToonInfoBox>작가 <ToonInfoData>{FakeWebtoonData[0].author}</ToonInfoData></ToonInfoBox>
+                        <ToonInfoBox>작품설명 <ToonInfoData>{FakeWebtoonData[0].expla}</ToonInfoData></ToonInfoBox>
+                    </ToonInfoContainer>
+        </ToonContentContainer>
+    );
+};
+export default ToonContent;
+
+const ToonContentContainer = styled.div`
+    display: flex;
+    padding: 15px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    margin-top: 40px;
+`;
+
+const ToonImgContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-left: 20px;
+    margin-right: 20px;
+`
+
+const Img = styled.img`
+    width: 100px;
+    height: 100px;
+`;
+
+const ToonInfoContainer = styled.div`
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+`
+const ToonInfoBox = styled.div`
+    display: flex;
+    align-items: center;
+    margin: 10px;
+`
+const ToonInfoData = styled.div`
+    background-color: ${theme.colors.textBox};
+    height: 25px;
+    padding: 1px 7px 1px 7px;
+    margin-left: 10px;
+    border-radius: 8px;
+    box-shadow: 0 5px 10px rgba(0,0,0,0.05), 0 2px 2px rgba(0,0,0,0.10);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`


### PR DESCRIPTION
## 🔥 Related Issues
-----
resolved #34 

## 💜 TodoList
-----
- [x] 수정, 삭제 버튼 구현
- [x] 제목, 작가 등의 상세정보와 회차 리스트 구현

## ✅ PR Point
-----
- 단독 상세 페이지가 아닌 작품 관리, 작품 조회 페이지에서 해당 웹툰 클릭시 해당 웹툰의 정보가 들어간 상세 페이지 나타나도록 구현할 필요.

## 👀 Screenshot / GIF / Link
-----
![image](https://github.com/webtoon-erp/front/assets/109736890/1906d060-774c-4e26-a20c-641cb57b6c88)
