### PR TITLE
feat: 전체 웹툰 리스트, 웹툰 상세 보기 화면 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,8 @@ import ToonAdd from './pages/webtoon/toonAdd';
 
 import EpisodeAddComponent from './component/forWebtoon/forToonAdd/EpisodeAddComponent';
 import EpisodeAdd from './pages/webtoon/episodeAdd';
+import AllToonView from './pages/webtoon/allToonView';
+import ToonDetail from './pages/webtoon/toonDetail';
 function App() {
   return (
     <>
@@ -71,6 +73,8 @@ function App() {
               <Route path="/toonAdd" element={<ToonAdd/>} />
               <Route path="/episodeAdd" element={<EpisodeAdd />} />
               <Route path="/toonView" element={<ToonView />} />
+              <Route path="/toonDetail" element={<ToonDetail />} />
+              <Route path="/allToonView" element={<AllToonView />} />
               <Route path="/epRequestAdd" element={<EpRequestAdd />} />
               <Route path="/epRequestList" element={<EpRequestList />} />
               <Route path="/epRequestView" element={<EpRequestView />} />

--- a/src/component/forHr/forHrAttendance/WholeAttendance.jsx
+++ b/src/component/forHr/forHrAttendance/WholeAttendance.jsx
@@ -8,15 +8,17 @@ import styled from 'styled-components';
 export default function WholeAttendance() {
 
     const rowData = [
-      {'전체 직원': 69, '출근': 66, '사내': 50, '사외': 10, '재택': 6},
+      {'전체 직원': 69, '출근': 66, '퇴근': 50, '미출근': 0, '지각': 6, '휴가': 6, '연장근무': 6},
   ];
 
   const columnDefs = [
       {field: '전체 직원'},
       {field: '출근'},
-      {field: '사내'},
-      {field: '사외'},
-      {field: '재택'},
+      {field: '퇴근'},
+      {field: '미출근'},
+      {field: '지각'},
+      {field: '휴가'},
+      {field: '연장근무'},
   ];
 
   // useEffect(() => {
@@ -46,7 +48,7 @@ const WholeAttendanceContainer = styled.div`
     padding: 10px;
     border: 1px solid #ccc;
     border-radius: 8px;
-    height: 190px;
+    height: 210px;
     width: 100%
 `;
 
@@ -56,5 +58,5 @@ const Title = styled.h3`
 
 const WholeAttendanceGrid = styled.div`
     width: 900px;
-    height: 110px;
+    height: 140px;
 `

--- a/src/component/forNotice/NoticeComponent.jsx
+++ b/src/component/forNotice/NoticeComponent.jsx
@@ -198,7 +198,7 @@ const NoticeComponent = () => {
     };
   
     // 선택된 부서에 해당하는 프로필 필터링
-    const filteredNotices = selectedTag === '전체' ? fakeData : fakeData.filter((emp) => emp.tag === selectedTag);
+    const filteredNotices = fakeData.filter((emp) => emp.tag === selectedTag);
   
     // ag-grid
     const columnDefs = [

--- a/src/component/forWebtoon/forAllWebtoon/allWebtoonListView.jsx
+++ b/src/component/forWebtoon/forAllWebtoon/allWebtoonListView.jsx
@@ -1,0 +1,286 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+import SearchComponent from '../../search';
+
+const fakeData = [
+    {
+      id: 1,
+      day: '월',
+      title: '월요일웹툰1',
+      author: 'author 1',
+      drawer: 'drawer 1',
+      keyword: '코미디',
+      url: '/data1',
+    },
+    {
+        id: 2,
+        day: '월',
+        title: '월요일웹툰2',
+        author: 'author 2',
+        drawer: 'drawer 2',
+        keyword: '코미디',
+        url: '/data2',
+      },
+      {
+        id: 3,
+        day: '월',
+        title: '월요일웹툰3',
+        author: 'author 3',
+        drawer: 'drawer 3',
+        keyword: '코미디',
+        url: '/data3',
+      },
+      {
+        day: '화',
+        title: '화요일웹툰1',
+        author: 'author 1',
+        drawer: 'drawer 1',
+        keyword: '코미디',
+        url: '/data1',
+      },
+      {
+          day: '화',
+          title: '화요일웹툰2',
+          author: 'author 2',
+          drawer: 'drawer 2',
+          keyword: '코미디',
+          url: '/data2',
+        },
+        {
+          day: '화',
+          title: '월요일웹툰3',
+          author: 'author 3',
+          drawer: 'drawer 3',
+          keyword: '코미디',
+          url: '/data3',
+        },
+        {
+            day: '수',
+            title: '수요일웹툰1',
+            author: 'author 1',
+            drawer: 'drawer 1',
+            keyword: '코미디',
+            url: '/data1',
+          },
+          {
+              day: '수',
+              title: '수요일웹툰2',
+              author: 'author 2',
+              drawer: 'drawer 2',
+              keyword: '코미디',
+              url: '/data2',
+            },
+            {
+              day: '수',
+              title: '수요일웹툰3',
+              author: 'author 3',
+              drawer: 'drawer 3',
+              keyword: '코미디',
+              url: '/data3',
+            },
+            {
+                day: '목',
+                title: '목요일웹툰1',
+                author: 'author 1',
+                drawer: 'drawer 1',
+                keyword: '코미디',
+                url: '/data1',
+              },
+              {
+                  day: '목',
+                  title: '목요일웹툰2',
+                  author: 'author 2',
+                  drawer: 'drawer 2',
+                  keyword: '코미디',
+                  url: '/data2',
+                },
+                {
+                  day: '목',
+                  title: '목요일웹툰3',
+                  author: 'author 3',
+                  drawer: 'drawer 3',
+                  keyword: '코미디',
+                  url: '/data3',
+                },
+                {
+                    day: '금',
+                    title: '금요일웹툰1',
+                    author: 'author 1',
+                    drawer: 'drawer 1',
+                    keyword: '코미디',
+                    url: '/data1',
+                  },
+                  {
+                      day: '금',
+                      title: '금요일웹툰2',
+                      author: 'author 2',
+                      drawer: 'drawer 2',
+                      keyword: '코미디',
+                      url: '/data2',
+                    },
+                    {
+                      day: '금',
+                      title: '금요일웹툰3',
+                      author: 'author 3',
+                      drawer: 'drawer 3',
+                      keyword: '코미디',
+                      url: '/data3',
+                    },
+                    {
+                        day: '토',
+                        title: '토요일웹툰1',
+                        author: 'author 1',
+                        drawer: 'drawer 1',
+                        keyword: '코미디',
+                        url: '/data1',
+                      },
+                      {
+                          day: '토',
+                          title: '토요일웹툰2',
+                          author: 'author 2',
+                          drawer: 'drawer 2',
+                          keyword: '코미디',
+                          url: '/data2',
+                        },
+                        {
+                          day: '토',
+                          title: '토요일웹툰3',
+                          author: 'author 3',
+                          drawer: 'drawer 3',
+                          keyword: '코미디',
+                          url: '/data3',
+                        },
+                        {
+                            day: '일',
+                            title: '일요일웹툰1',
+                            author: 'author 1',
+                            drawer: 'drawer 1',
+                            keyword: '코미디',
+                            url: '/data1',
+                          },
+                          {
+                              day: '일',
+                              title: '일요일웹툰2',
+                              author: 'author 2',
+                              drawer: 'drawer 2',
+                              keyword: '코미디',
+                              url: '/data2',
+                            },
+                            {
+                              day: '일',
+                              title: '일요일웹툰3',
+                              author: 'author 3',
+                              drawer: 'drawer 3',
+                              keyword: '코미디',
+                              url: '/data3',
+                            },
+  ];
+
+const AllWebtoonListView = () => {
+    const [selectedDay, setSelectedDay] = useState('전체');
+  
+    // 태그 선택 핸들러
+    const selectDayHandler = (e) => {
+        setSelectedDay(e.target.value);
+    };
+  
+    // 선택된 부서에 해당하는 프로필 필터링
+    const filteredDays = selectedDay === '전체' ? fakeData : fakeData.filter((emp) => emp.day === selectedDay);
+  
+    // ag-grid
+    const columnDefs = [
+      { headerName: '요일', field: 'day', width: 100 },
+      { headerName: '제목', field: 'title', width: 400 },
+      { headerName: '작가', field: 'author', width: 120 },
+      { headerName: '그림', field: 'drawer', width: 120 },
+      { headerName: '키워드', field: 'keyword', width: 280 },
+    ];
+  
+    const gridOptions = {
+      columnDefs: columnDefs,
+      rowData: filteredDays,
+      rowSelection: 'single',
+      animateRows: true,
+      pagination: true,
+      paginationPageSize: 10,
+      onCellClicked: handleCellClick,
+    };
+  
+    // 셀 클릭 핸들러
+    function handleCellClick(event) {
+      const column = event.colDef.field;
+      const rowData = event.data;
+      const url = rowData.url;
+      if (column  && url) {
+        window.location.href = url;
+      }
+    }
+
+    return (
+        <>
+          <Title>전체 웹툰</Title>
+            <ToonContainer>
+                <SelectTagContainer>
+                <select value={selectedDay} onChange={selectDayHandler}>
+                    <option value="전체">전체</option>
+                    <option value="월">월</option>
+                    <option value="화">화</option>
+                    <option value="수">수</option>
+                    <option value="목">목</option>
+                    <option value="금">금</option>
+                    <option value="토">토</option>
+                    <option value="일">일</option>
+                </select>
+                <Container />
+                    <SearchComponent />
+                </SelectTagContainer>
+                
+                <div className="ag-theme-alpine" style={{ height: '400px', width: '1050px' }}>
+                <AgGridReact
+                    columnDefs={columnDefs}
+                    rowData={filteredDays}
+                    gridOptions={gridOptions}
+                />
+                </div>
+            </ToonContainer>
+        </>
+    )
+}
+
+export default AllWebtoonListView;
+
+
+const ToonContainer = styled.div`
+display: flex;
+flex-direction: column;
+align-items: flex-start;
+
+padding: 50px;
+padding-left: 70px;
+`;
+
+const SelectTagContainer = styled.div`
+margin-bottom: 20px;
+
+select {
+  width: 150px;
+  height: 35px;
+}
+display: flex;
+flex-direction: row;
+`;
+
+const Title = styled.div`
+font-size: 30px;
+padding-top: 120px;
+padding-left: 4%;
+font-weight: bold;
+`;
+
+const Container = styled.div`
+padding-left: 600px;
+`;

--- a/src/component/forWebtoon/forToonDetail/toonDetailComponent.jsx
+++ b/src/component/forWebtoon/forToonDetail/toonDetailComponent.jsx
@@ -1,0 +1,231 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import styled from 'styled-components';
+import theme from '../../../style/theme';
+
+const FakeProfileData = [
+    {
+        id: 1,
+        title: '엔딩, 바꿔보려합니다',
+        author: 'author',
+        drawer: 'drawer',
+        day: '월요일',
+        keyword: '코미디',
+        content: '010-1234-1234',
+        rank: 'title 1 썸네일',
+        thumnailPreview: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRbxgxO2HlWpJnmMF19T9mPjPypU5Q7R5Dcfg&usqp=CAU',
+        content: `배드엔딩만 쓰는 피폐소설작가 변수아는
+        누군가의 저주로 인해 현재 연재중인 ‘청춘의 끝에’의 악녀 최세화로 빙의된다.
+        인성파탄자, 소시오패스, 이중인격자, 싸이코패스뿐인 소설 속에서
+        과연 수아는 살아서 원래 세계로 돌아갈 수 있을까?`,
+    },
+];
+
+
+const ToonDetailComponent = (Id) => {
+    //수정 가능 여부
+    const [editable, setEditable] = useState('false');
+    const [enrollable, setEnrollable] = useState('false');
+
+    const [selectedTitle, setSelectedTitle] = useState('');
+    const [selectedAuthor, setSelectedAuthor] = useState('');
+    const [selectedDrawer, setSelectedDrawer] = useState('');
+    const [selectedDay, setSelectedDay] = useState('');
+    const [selectedKeyword, setSelectedKeyword] = useState('');
+    const [selectedContent, setSelectedContent] = useState('');
+    const [thumbnailPreview, setThumbnailPreview] = useState(null);
+
+    //data.title
+    //const [data, setData] = useState({});
+
+    //seEffect(() => {
+    //    axios.get('http://localhost:5050/quals/'+Id).then((response)=> {
+    //      setData(response.data);
+    //      //console.log("ddddddd");
+    //    })
+    //  }, []);
+    
+    
+
+    const SelectTitlehandler = (e) => {
+        setSelectedTitle(e.target.value);
+      };
+    
+      const SelectAuthorhandler = (e) => {
+        setSelectedAuthor(e.target.value);
+      };
+    
+      const SelectDrawerhandler = (e) => {
+        setSelectedDrawer(e.target.value);
+      };
+    
+      const SelectDayhandler = (e) => {
+        setSelectedDay(e.target.value);
+      };
+    
+      const SelectKeywordhandler = (e) => {
+        setSelectedKeyword(e.target.value);
+      };
+    
+      const SelectContenthandler = (e) => {
+        setSelectedContent(e.target.value);
+      };
+    
+      const handleThumbnailChange = (e) => {
+        const file = e.target.files[0];
+        const reader = new FileReader();
+    
+        reader.onload = (event) => {
+          setThumbnailPreview(event.target.result);
+        };
+    
+        if (file) {
+          reader.readAsDataURL(file);
+        }
+      };
+    
+      const handleSubmitClick = () => {
+         //console.log(finalId, "finalId 결과값"); 
+    
+        axios.post('http://localhost:5050/register',
+          {
+            selectedTitle: selectedTitle,           
+            selectedAuthor: selectedAuthor,  
+            selectedDrawer: selectedDrawer,  
+            selectedDay: selectedDay,           
+            selectedKeyword: selectedKeyword,
+            selectedContent: selectedContent,
+            thumbnailPreview: thumbnailPreview,
+          },
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          })
+          .then((result) => {
+            console.log(result);
+            console.log("enroll!");
+            window.alert('작품 상세정보가 정상적으로 수정되었습니다.');
+            //window.location.replace("/login"); 
+          })
+          .catch((error) => {
+            window.alert('작품 상세정보가 정상적으로 수정되지 않았습니다.');
+            console.log(error);
+          })
+      };
+
+    return (
+        <>
+            <RegistBtnContainer>
+                        <RegistBtn onClick={handleSubmitClick}>수정</RegistBtn>
+                        <RegistBtn onClick={handleSubmitClick}>등록</RegistBtn>
+            </RegistBtnContainer>
+            
+            <WebtoonContainer>
+                        <WebtoonImgContainer>
+                            <Img src={FakeProfileData[0].thumnailPreview} alt={`${FakeProfileData[0].rank} ${FakeProfileData[0].name}의 프로필 사진`} />
+                        </WebtoonImgContainer>
+                        <ToonInsideInfoBox>
+                            <ToonTitle>{FakeProfileData[0].title}</ToonTitle>
+                            
+                            <ToonInfoContainer>
+                                <ToonInfoBox>작가 <ToonInfoData>{FakeProfileData[0].author}</ToonInfoData></ToonInfoBox>
+                                <ToonInfoBox>그림 <ToonInfoData>{FakeProfileData[0].drawer}</ToonInfoData></ToonInfoBox>
+                                <ToonInfoBox>업로드 요일 <ToonInfoData>{FakeProfileData[0].day}</ToonInfoData></ToonInfoBox>
+                                <ToonInfoBox>키워드 <ToonInfoData>{FakeProfileData[0].keyword}</ToonInfoData></ToonInfoBox>
+                            </ToonInfoContainer>
+                            <ToonInsideInfoTextBox>
+                                <ToonInfoBox>작품 설명 <ToonInfoTextData>{FakeProfileData[0].content}</ToonInfoTextData></ToonInfoBox>
+                            </ToonInsideInfoTextBox>
+                        </ToonInsideInfoBox>
+            </WebtoonContainer>
+        </>
+    )
+};
+
+export default ToonDetailComponent;
+
+const RegistBtnContainer = styled.div`
+    display: flex;
+    padding-left: 70%;
+    margin-bottom: 20px;
+`;
+
+const RegistBtn = styled.button`
+    width: 100px;
+    height: 40px;
+    background-color: ${theme.colors.btn};
+    border: none;
+    color: ${theme.colors.white};
+    text-align: center;
+    border-radius: 8px;
+    box-shadow: 0 5px 10px rgba(0,0,0,0.10), 0 2px 2px rgba(0,0,0,0.20);
+    &:hover {
+        background-color: #00B757;
+    }
+    cursor: pointer;
+    margin: 0px 15px 0px 15px;
+`
+
+const WebtoonContainer = styled.div`
+    display: flex;
+    padding: 20px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+`;
+
+const WebtoonImgContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-left: 20px;
+    margin-right: 20px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+`
+
+const Img = styled.img`
+    width: 180px;
+    height: 270px;
+`;
+
+const ToonInfoContainer = styled.div`
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+`
+const ToonInfoBox = styled.div`
+    display: flex;
+    margin: 20px;
+`
+const ToonInsideInfoBox = styled.div`
+    display: flex;
+    flex-direction: column;
+`
+const ToonInsideInfoTextBox = styled.div`
+    
+`
+
+const ToonInfoData = styled.div`
+    background-color: ${theme.colors.textBox};
+    height: 25px;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin-left: 10px;
+    border-radius: 8px;
+    box-shadow: 0 5px 10px rgba(0,0,0,0.05), 0 2px 2px rgba(0,0,0,0.10);
+`
+const ToonInfoTextData = styled.div`
+    background-color: ${theme.colors.textBox};
+    height: 75px;
+    width: 650px;
+    padding: 5px;
+    padding-top: 10px;
+    margin-left: 10px;
+    border-radius: 8px;
+    box-shadow: 0 5px 10px rgba(0,0,0,0.05), 0 2px 2px rgba(0,0,0,0.10);
+`
+const ToonTitle = styled.div`
+    font-size: 23px;
+    margin: 15px;
+    font-weight: bold;
+`

--- a/src/component/forWebtoon/forToonDetail/toonGrid.jsx
+++ b/src/component/forWebtoon/forToonDetail/toonGrid.jsx
@@ -1,0 +1,99 @@
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import styled from 'styled-components'
+import HorizonLine from '../../horizonLine';
+import { Link } from 'react-router-dom';
+
+const fakeData = [
+    {
+        thumnail: '',
+        count: '1',
+        title: '에피소드1',
+        manager: '또롱',
+        date: '2023-07-17',
+        url: '/toon1',
+    },
+]
+
+const ToonGrid = (Id) => {
+    const Toons =  fakeData
+  
+
+    // ag-grid
+    const columnDefs = [
+        { headerName: '회차 번호', field: 'count', width: 150},
+        { headerName: '회차 제목', field: 'title', width: 450}, 
+        { headerName: '업로드 일자', field: 'date', width: 300},    
+        { headerName: '담당자', field: 'manager', width: 150},    
+    ];
+
+    const gridOptions = {
+        columnDefs: columnDefs,
+        rowData: Toons,
+        rowSelection: 'single',
+        animateRows: true,
+        pagination: true,
+        paginationPageSize: 10,
+        onCellClicked: handleCellClick,
+      };
+    
+      // 셀 클릭 핸들러
+      function handleCellClick(event) {
+        const column = event.colDef.field;
+        const Toons = event.data;
+        const url = Toons.url;
+        if (column  && url) {
+          window.location.href = url;
+        }
+      }
+
+
+    //data.title
+    //const [data, setData] = useState({});
+
+    //useEffect(() => {
+    //    axios.get('http://localhost:5050/quals/'+Id).then((response)=> {
+    //      setData(response.data);
+    //      //console.log("ddddddd");
+    //    })
+    //  }, []);
+
+    return (
+        <ToonGridContainer>
+            <Title>회차정보</Title>
+            <HorizonLine />
+            <Toon className="ag-theme-alpine">
+                <AgGridReact 
+                    rowData={Toons}
+                    columnDefs={columnDefs}
+                    animateRows={true}
+                    gridOptions={gridOptions}
+                
+                />
+            </Toon>
+        </ToonGridContainer>
+        
+    )
+};
+
+export default ToonGrid;
+
+const ToonGridContainer = styled.div`
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    width: 1020px;
+    height: 500px;
+`;
+
+const Title = styled.h3`
+    margin-left: 10px;
+`;
+
+const Toon = styled.div`
+    width: 1020px;
+    height: 400px;
+`

--- a/src/pages/hr/hrAttendance.js
+++ b/src/pages/hr/hrAttendance.js
@@ -33,16 +33,9 @@ export default function HrAttendance() {
         <Container>
                 <WholeAttendance />
         </Container>
-        <Container>      
-                    <TodayAttendance />
-        </Container>
         <Container> 
             <WorkExtension />
-            <DepartmentVacation />
-            <VacationRemain /> 
-        </Container>
-        <Container> 
-              <WholeVacation />
+            <DepartmentVacation /> 
         </Container>
     </>
   );

--- a/src/pages/webtoon/allToonView.js
+++ b/src/pages/webtoon/allToonView.js
@@ -1,0 +1,9 @@
+import AllWebtoonListView from "../../component/forWebtoon/forAllWebtoon/allWebtoonListView";
+
+export default function AllToonView (){
+    return(
+        <>
+            <AllWebtoonListView />
+        </>
+    )
+}

--- a/src/pages/webtoon/toonDetail.js
+++ b/src/pages/webtoon/toonDetail.js
@@ -1,0 +1,45 @@
+import ToonDetailComponent from "../../component/forWebtoon/forToonDetail/toonDetailComponent";
+import styled from 'styled-components'
+import ToonGrid from "../../component/forWebtoon/forToonDetail/toonGrid";
+import theme from '../../style/theme';
+import axios from 'axios';
+
+export default function ToonDetail (){
+
+    return(
+        <>
+         <Title>웹툰 상세보기</Title>
+         <Container>
+            <ToonDetailContainer>
+                <ToonDetailComponent/>
+            </ToonDetailContainer>
+            <ToonGridContainer>
+                <ToonGrid />
+            </ToonGridContainer>
+         </Container>
+        </>
+    )
+}
+
+const ToonDetailContainer = styled.div`
+display: flex;
+flex-direction: column;
+align-items: flex-start;
+padding-left: 70px;
+`;
+
+const ToonGridContainer = styled.div`
+padding: 20px;
+padding-left: 70px;
+width: 500px;
+`;
+
+const Title = styled.div`
+font-size: 30px;
+padding-top: 120px;
+padding-left: 4%;
+font-weight: bold;
+`;
+
+const Container = styled.div`
+`;


### PR DESCRIPTION
## ✅ PR Point
-----
- ag-grid 이용하여 전체 웹툰 리스트 구현, 각 컬럼 클릭 시 해당 페이지로 이동하는 기능 구현해두었습니다.
- 지난 회의 내용과 과거 웹툰 등록 화면 구성 사항 모두 반영하여 웹툰 상세보기 화면 구현하였습니다.
- 
![image](https://github.com/webtoon-erp/front/assets/107592904/c9df11cd-f8c4-4392-b2d7-17002d7de3f2)
![image](https://github.com/webtoon-erp/front/assets/107592904/aa175ce2-9f44-4ba1-b74a-ac850ad230b1)
