### PR TITLE
feat: 내 문서, 부서, 결재대기, 참조 문서 조회 페이지 구현

### DIFF
--- a/src/component/forElectropayment/depDocsView.jsx
+++ b/src/component/forElectropayment/depDocsView.jsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+
+const DepDocsView = () => {
+    const columnDefs = [      
+        {field: '문서종류', sortable: true, filter: true, width: '130px'},
+        {field: '작성일', sortable: true, filter: true, width: '150px'},
+        {field: '제목', sortable: true, filter: true, width: '250px'},
+        {field: '부서', sortable: true, filter: true, width: '130px'},
+        {field: '작성자', sortable: true, filter: true, width: '110px'},
+        {field: '결재대기자', sortable: true, filter: true, width: '168px'},
+        {field: '최종결재자', sortable: true, filter: true, width: '130px'},
+        {field: '상태', sortable: true, filter: true, width: '130px',  
+            cellStyle: params=> {
+                if(params.value === '상신') {
+                    return {color:'#F8F1F1', 'background-color':'#91CDF2', 'font-weight': 'bold'}
+                } else return {color:'#F8F1F1', 'background-color':'#F2ACBF', 'font-weight': 'bold'}
+        }},
+    ];
+
+    const rowData = [
+        {문서종류: '종류', 작성일 : '2023-08-02', 제목: '제목을 뭘 적어야하나', 부서: '인사부', 작성자: '나', 결재대기자: '', 최종결재자: '홍길동', 상태: '상신', url: '/content1'},
+        {문서종류: '종류', 작성일 : '2023-07-02', 제목: '제목 내 맘대로 할거야', 부서: '인사부', 작성자: '나', 결재대기자: '김철수', 최종결재자: '박영희', 상태: '임시', url: '/content2'},
+    ];
+
+    function handleCellClick(event) {
+        const column = event.colDef.field;
+        const requests = event.data;
+        const url = requests.url;
+        if (column  && url) {
+            window.location.href = url;
+        }
+    }
+
+    return (
+        <>
+                <Title>부서 문서 조회</Title>                
+                <EntitlementGrid className="ag-theme-alpine">
+                        <AgGridReact
+                            rowData={rowData}
+                            columnDefs={columnDefs}
+                            animateRows={true}
+                            rowSelection='multiple'
+                            pagination= {true}
+                            paginationPageSize= {20}
+                            onCellClicked= {handleCellClick}
+                        />
+                </EntitlementGrid>
+        </>
+    )
+};
+
+export default DepDocsView;
+
+const Title = styled.div`
+    font-size: 30px;
+    font-weight: bold;
+`;
+
+const EntitlementGrid = styled.div`
+    margin-top: 40px;
+    width: 1200px;
+    height: 960px;
+`

--- a/src/component/forElectropayment/myDocsView.jsx
+++ b/src/component/forElectropayment/myDocsView.jsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+
+const MyDocsView = () => {
+    const columnDefs = [      
+        {field: '문서종류', sortable: true, filter: true, width: '130px'},
+        {field: '작성일', sortable: true, filter: true, width: '150px'},
+        {field: '제목', sortable: true, filter: true, width: '250px'},
+        {field: '부서', sortable: true, filter: true, width: '130px'},
+        {field: '작성자', sortable: true, filter: true, width: '110px'},
+        {field: '결재대기자', sortable: true, filter: true, width: '168px'},
+        {field: '최종결재자', sortable: true, filter: true, width: '130px'},
+        {field: '상태', sortable: true, filter: true, width: '130px',  
+            cellStyle: params=> {
+                if(params.value === '상신') {
+                    return {color:'#F8F1F1', 'background-color':'#91CDF2', 'font-weight': 'bold'}
+                } else return {color:'#F8F1F1', 'background-color':'#F2ACBF', 'font-weight': 'bold'}
+        }},
+    ];
+
+    const rowData = [
+        {문서종류: '종류', 작성일 : '2023-08-02', 제목: '제목을 뭘 적어야하나', 부서: '인사부', 작성자: '나', 결재대기자: '', 최종결재자: '홍길동', 상태: '상신', url: '/content1'},
+        {문서종류: '종류', 작성일 : '2023-07-02', 제목: '제목 내 맘대로 할거야', 부서: '인사부', 작성자: '나', 결재대기자: '김철수', 최종결재자: '박영희', 상태: '임시', url: '/content2'},
+    ];
+
+    function handleCellClick(event) {
+        const column = event.colDef.field;
+        const requests = event.data;
+        const url = requests.url;
+        if (column  && url) {
+            window.location.href = url;
+        }
+    }
+
+    return (
+        <>
+                <Title>내 문서 조회</Title>                
+                <EntitlementGrid className="ag-theme-alpine">
+                        <AgGridReact
+                            rowData={rowData}
+                            columnDefs={columnDefs}
+                            animateRows={true}
+                            rowSelection='multiple'
+                            pagination= {true}
+                            paginationPageSize= {20}
+                            onCellClicked= {handleCellClick}
+                        />
+                </EntitlementGrid>
+        </>
+    )
+};
+
+export default MyDocsView;
+
+const Title = styled.div`
+    font-size: 30px;
+    font-weight: bold;
+`;
+
+const EntitlementGrid = styled.div`
+    margin-top: 40px;
+    width: 1200px;
+    height: 960px;
+`

--- a/src/component/forElectropayment/refDocsView.jsx
+++ b/src/component/forElectropayment/refDocsView.jsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+
+const RefDocsView = () => {
+    const columnDefs = [      
+        {field: '문서종류', sortable: true, filter: true, width: '130px'},
+        {field: '작성일', sortable: true, filter: true, width: '150px'},
+        {field: '제목', sortable: true, filter: true, width: '250px'},
+        {field: '부서', sortable: true, filter: true, width: '130px'},
+        {field: '작성자', sortable: true, filter: true, width: '110px'},
+        {field: '결재대기자', sortable: true, filter: true, width: '168px'},
+        {field: '최종결재자', sortable: true, filter: true, width: '130px'},
+        {field: '상태', sortable: true, filter: true, width: '130px', 
+            cellStyle: params=> {
+                if(params.value === '상신') {
+                    return {color:'#F8F1F1', 'background-color':'#91CDF2', 'font-weight': 'bold'}
+                } else return {color:'#F8F1F1', 'background-color':'#F2ACBF', 'font-weight': 'bold'}
+        }},
+    ];
+
+    const rowData = [
+        {문서종류: '종류', 작성일 : '2023-08-02', 제목: '제목을 뭘 적어야하나', 부서: '인사부', 작성자: '나', 결재대기자: '', 최종결재자: '홍길동', 상태: '상신', url: '/content1'},
+        {문서종류: '종류', 작성일 : '2023-07-02', 제목: '제목 내 맘대로 할거야', 부서: '인사부', 작성자: '나', 결재대기자: '김철수', 최종결재자: '박영희', 상태: '임시', url: '/content2'},
+    ];
+
+    function handleCellClick(event) {
+        const column = event.colDef.field;
+        const requests = event.data;
+        const url = requests.url;
+        if (column  && url) {
+            window.location.href = url;
+        }
+    }
+
+    return (
+        <>
+                <Title>참조 문서 조회</Title>                
+                <EntitlementGrid className="ag-theme-alpine">
+                        <AgGridReact
+                            rowData={rowData}
+                            columnDefs={columnDefs}
+                            animateRows={true}
+                            rowSelection='multiple'
+                            pagination= {true}
+                            paginationPageSize= {20}
+                            onCellClicked= {handleCellClick}
+                        />
+                </EntitlementGrid>
+        </>
+    )
+};
+
+export default RefDocsView;
+
+const Title = styled.div`
+    font-size: 30px;
+    font-weight: bold;
+`;
+
+const EntitlementGrid = styled.div`
+    margin-top: 40px;
+    width: 1200px;
+    height: 960px;
+`

--- a/src/pages/electropayment/epDepDocsView.js
+++ b/src/pages/electropayment/epDepDocsView.js
@@ -1,0 +1,16 @@
+import { styled } from "styled-components";
+import DepDocsView from "../../component/forElectropayment/depDocsView";
+
+export default function EpDepDocsView (){
+    return(
+        <DepDocsViewContainer>
+            <DepDocsView />
+        </DepDocsViewContainer>
+    )
+}
+
+const DepDocsViewContainer = styled.div`
+    margin-left: 40px;
+    margin-top: 120px;
+    width: 100%;
+`;

--- a/src/pages/electropayment/epHoldenDocsView.js
+++ b/src/pages/electropayment/epHoldenDocsView.js
@@ -1,0 +1,16 @@
+import { styled } from "styled-components";
+import HoldenDocsView from "../../component/forElectropayment/holdenDocsView";
+
+export default function EpHoldenDocsView (){
+    return(
+        <HoldenDocsViewContainer>
+            <HoldenDocsView />
+        </HoldenDocsViewContainer>
+    )
+}
+
+const HoldenDocsViewContainer = styled.div`
+    margin-left: 40px;
+    margin-top: 120px;
+    width: 100%;
+`;

--- a/src/pages/electropayment/epMyDocsView.js
+++ b/src/pages/electropayment/epMyDocsView.js
@@ -1,0 +1,16 @@
+import MyDocsView from "../../component/forElectropayment/myDocsView";
+import { styled } from "styled-components";
+
+export default function EpMyDocsView (){
+    return(
+        <MyDocsViewContainer>
+            <MyDocsView />
+        </MyDocsViewContainer>
+    )
+}
+
+const MyDocsViewContainer = styled.div`
+    margin-left: 40px;
+    margin-top: 120px;
+    width: 100%;
+`;

--- a/src/pages/electropayment/epRefDocsView.js
+++ b/src/pages/electropayment/epRefDocsView.js
@@ -1,0 +1,16 @@
+import RefDocsView from "../../component/forElectropayment/refDocsView";
+import { styled } from "styled-components";
+
+export default function EpRefDocsView (){
+    return(
+        <RefDocsViewContainer>
+            <RefDocsView />
+        </RefDocsViewContainer>
+    )
+}
+
+const RefDocsViewContainer = styled.div`
+    margin-left: 40px;
+    margin-top: 120px;
+    width: 100%;
+`;


### PR DESCRIPTION
## 🔥 Related Issues
-----
resolved #49 

## 💜 TodoList
-----
- [x] 전자 결재 리스트 조회 페이지 구현 (ag-grid)
- [x]  각각 셀 클릭시 해당 전자결재의 상세 페이지로 이동


## 👀 Screenshot / GIF / Link
-----
![image](https://github.com/webtoon-erp/front/assets/109736890/cd69d9d9-48fb-4057-aec9-8857f16c04dd)
(나머지 문서들도 해당 양식과 같음)