### PR TITLE
feat: 전체 일정 조회, 일정 등록 페이지 구현 및 간단한 레이아웃 조정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,8 @@ import EpRefDocsView from './pages/electropayment/epRefDocsView';
 import NoticeAdd from './pages/system/noticeAdd';
 import Tab from './component/Tab';
 import TabComponent from './component/TabComponent';
+import ScheduleAdd from './pages/system/scheduleAdd';
+import Schedule from './pages/common/schedule';
 
 
 function App() {
@@ -130,6 +132,8 @@ function App() {
               <Route path="/epHoldenDocsView" element={<EpHoldenDocsView />} />
               <Route path="/epRefDocsView" element={<EpRefDocsView />} />
               <Route path="/noticeAdd" element={<NoticeAdd />} />
+              <Route path="/scheduleAdd" element={<ScheduleAdd />} />
+              <Route path="/schedule" element={<Schedule />} />
               {tabElements.map((tab, index) => (
               <Route
                   key={index}

--- a/src/component/forCalendar/calendarComponent.jsx
+++ b/src/component/forCalendar/calendarComponent.jsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+import SearchComponent from '../search';
+
+
+const CalendarComponent = () => {
+    const [selectedTag, setSelectedTag] = useState('전체');
+  
+    // ag-grid
+    const columnDefs = [
+      { headerName: '제목', field: 'title', width: 350 },
+      { headerName: '작성자', field: 'author', width: 100 },
+      { headerName: '작성일자', field: 'date', width: 200 },
+      { headerName: '시작일자', field: 'date', width: 200 },
+      { headerName: '종료일자', field: 'date', width: 200 },
+    ];
+
+
+    // 선택된 부서에 해당하는 프로필 필터링
+    const filteredDays = selectedTag 
+  
+  
+    const gridOptions = {
+      columnDefs: columnDefs,
+      rowSelection: 'single',
+      animateRows: true,
+      pagination: true,
+      paginationPageSize: 10,
+      onCellClicked: handleCellClick,
+    };
+  
+    // 셀 클릭 핸들러
+    function handleCellClick(event) {
+      const column = event.colDef.field;
+      const rowData = event.data;
+      const url = rowData.url;
+      if (column  && url) {
+        window.location.href = url;
+      }
+    }
+  
+    return (
+    <>
+     <Title>일정 조회</Title>
+
+      <NoticeContainer>
+        <SelectDepContainer>
+          <select value={selectedTag}>
+            <option value="전체">전체</option>
+            <option value="서비스">서비스</option>
+            <option value="시스템">시스템</option>
+            <option value="행사">행사</option>
+          </select>
+          <Container />
+            <SearchComponent />
+        </SelectDepContainer>
+        
+        <div className="ag-theme-alpine" style={{ height: '400px', width: '1050px' }}>
+          <AgGridReact
+            columnDefs={columnDefs}
+            rowData={filteredDays}
+            gridOptions={gridOptions}
+          />
+        </div>
+      </NoticeContainer>
+      </>
+
+    );
+  };
+  
+  export default CalendarComponent;
+  
+  const NoticeContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    padding: 50px;
+    padding-left: 70px;
+  `;
+  
+  const SelectDepContainer = styled.div`
+    margin-bottom: 20px;
+  
+    select {
+      width: 150px;
+      height: 35px;
+    }
+    display: flex;
+    flex-direction: row;
+  `;
+
+  const Title = styled.div`
+  font-size: 30px;
+  padding-top: 40px;
+  padding-left: 4%;
+  font-weight: bold;
+`;
+
+const Container = styled.div`
+    padding-left: 600px;
+  `;

--- a/src/component/forCalendar/forCalendarRegist.jsx
+++ b/src/component/forCalendar/forCalendarRegist.jsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import theme from '../../style/theme';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import axios from 'axios';
+import { ModuleRegistry } from '@ag-grid-community/core';
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { Button, Upload, message, Modal } from 'antd';
+
+
+const ForCalendarRegist = () => {
+  //달력(요청, 납기일)
+
+  const [registDate, setRegistDate] = useState(new Date());
+  const [selectedStartDate, setSelectedStartDate] = useState(null);
+  const [selectedEndDate, setSelectedEndDate] = useState(null);
+  const [selectedDeliveryDate, setSelectedDeliveryDate] = useState(null);
+  const [selectedTitle, setSelectedTitle] = useState('');
+  const [selectedRequest, setSelectedRequest] = useState('');
+
+  const handleSubmitClick = () => {
+    //console.log(finalId, "finalId 결과값"); 
+
+   axios.post('http://localhost:5050/register',
+     {
+      registDate: registDate,
+      selectedStartDate: selectedStartDate,  
+      selectedEndDate: selectedEndDate,  
+      selectedDeliveryDate: selectedDeliveryDate,  
+      selectedTitle: selectedTitle,
+      selectedRequest: selectedRequest,
+     },
+     {
+       headers: {
+         'Content-Type': 'application/json',
+       },
+     })
+     .then((result) => {
+       if (result.status === 'done') {
+        message.success(`[일정] 등록이 정상적으로 등록되었습니다.`);
+      } 
+     })
+     .catch((error) => {
+      message.error('[일정] 등록이 정상적으로 등록되지 않았습니다.');
+     })
+ };
+
+
+  const SelectTitlehandler = (e) => {
+    setSelectedTitle(e.target.value);
+  };
+
+  return (
+    <>
+      <Title>일정 등록</Title>
+      <RegistBtnContainer>
+                    <RegistBtn onClick={handleSubmitClick}>등록</RegistBtn>
+      </RegistBtnContainer>
+      
+      <MainContainer>
+          <Container>
+              <InputTitle>등록일</InputTitle>
+              <Div3 />
+              <DatePicker
+                selected={registDate}
+                dateFormat="yyyy-MM-dd"
+                disabled
+              />
+            </Container>
+            <Container>
+                <InputTitle>일정 제목</InputTitle><Div2/><Input type="text" placeholder="제목" onChange={SelectTitlehandler}/>
+            </Container>
+            <Container>
+              <InputTitle>시작일자</InputTitle>
+              <Div />
+              <DatePicker
+                  selected={selectedDeliveryDate}
+                  onChange={(date) => setSelectedStartDate(date)}
+                  dateFormat="yyyy-MM-dd"
+                  minDate={new Date()}
+                  placeholderText="납기일"
+                  />
+          </Container>
+          <Container>
+              <InputTitle>종료일자</InputTitle>
+              <Div />
+              <DatePicker
+                  selected={selectedDeliveryDate}
+                  onChange={(date) => setSelectedEndDate(date)}
+                  dateFormat="yyyy-MM-dd"
+                  minDate={new Date()}
+                  placeholderText="납기일"
+                  />
+          </Container>
+          
+
+      </MainContainer>
+      
+    </>
+  );
+};
+
+export default ForCalendarRegist;
+
+
+const MainContainer = styled.div`
+  display: flex;
+  border: 1px solid #ccc;
+  margin: 30px 50px;
+  height: 300px;
+  padding: 20px;
+  padding-left: 30%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Input = styled.input`
+  height: 30px;
+  border: transparent;
+  box-shadow: 0 5px 10px rgba(0,0,0,0.10), 0 2px 2px rgba(0,0,0,0.20);
+`;
+
+const InputTitle = styled.div`
+  font-size: 15px;
+  font-weight: bold;
+  padding: 15px;
+  padding-top: 7px;
+`;
+
+const Div = styled.div`
+  padding: 8px;
+`;
+
+const Div2 = styled.div`
+  padding: 5px;
+`;
+
+const Div3 = styled.div`
+  padding: 15px;
+`;
+
+const Title = styled.div`
+  font-size: 30px;
+  padding-top: 40px;
+  padding-left: 4%;
+  font-weight: bold;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  padding-left: 13px;
+  margin: 20px;
+`;
+
+const RegistBtnContainer = styled.div`
+    display: flex;
+    padding-left: 86%;
+`;
+
+const RegistBtn = styled.button`
+    width: 100px;
+    height: 40px;
+    background-color: ${theme.colors.btn};
+    border: none;
+    color: ${theme.colors.white};
+    text-align: center;
+    border-radius: 8px;
+    box-shadow: 0 5px 10px rgba(0,0,0,0.10), 0 2px 2px rgba(0,0,0,0.20);
+    &:hover {
+        background-color: #00B757;
+    }
+    cursor: pointer;
+    margin: 0px 15px 0px 15px;
+`

--- a/src/component/forITSM/serviceRequest.jsx
+++ b/src/component/forITSM/serviceRequest.jsx
@@ -452,7 +452,7 @@ const Div3 = styled.div`
 
 const Title = styled.div`
   font-size: 30px;
-  padding-top: 120px;
+  padding-top: 40px;
   padding-left: 4%;
   font-weight: bold;
 `;

--- a/src/component/forWebtoon/forAllWebtoon/allWebtoonListView.jsx
+++ b/src/component/forWebtoon/forAllWebtoon/allWebtoonListView.jsx
@@ -276,7 +276,7 @@ flex-direction: row;
 
 const Title = styled.div`
 font-size: 30px;
-padding-top: 120px;
+padding-top: 40px;
 padding-left: 4%;
 font-weight: bold;
 `;

--- a/src/component/forWebtoon/forToonAdd/EpisodeAddComponent.jsx
+++ b/src/component/forWebtoon/forToonAdd/EpisodeAddComponent.jsx
@@ -171,7 +171,7 @@ const Div3 = styled.div`
 
 const Title = styled.div`
   font-size: 30px;
-  padding-top: 120px;
+  padding-top: 40px;
   padding-left: 4%;
   font-weight: bold;
 `;

--- a/src/component/forWebtoon/forToonAdd/ToonAddComponent.jsx
+++ b/src/component/forWebtoon/forToonAdd/ToonAddComponent.jsx
@@ -197,7 +197,7 @@ const Div3 = styled.div`
 
 const Title = styled.div`
   font-size: 30px;
-  padding-top: 120px;
+  padding-top: 40px;
   padding-left: 4%;
   font-weight: bold;
 `;

--- a/src/pages/common/schedule.js
+++ b/src/pages/common/schedule.js
@@ -1,0 +1,9 @@
+import CalendarComponent from "../../component/forCalendar/calendarComponent";
+
+export default function Schedule (){
+    return(
+        <>
+          <CalendarComponent />
+        </>
+    )
+}

--- a/src/pages/system/scheduleAdd.js
+++ b/src/pages/system/scheduleAdd.js
@@ -1,0 +1,9 @@
+import ForCalendarRegist from "../../component/forCalendar/forCalendarRegist";
+
+export default function ScheduleAdd (){
+    return(
+        <>
+          <ForCalendarRegist />
+        </>
+    )
+}


### PR DESCRIPTION
## ✅ PR Point
-----
- 일정 조회, 일정 등록 페이지 각각 구현하였습니다.
- 탭 컴포넌트로 인해 레이아웃이 깨진 나머지 화면들 레이아웃 수정해놓았습니다.
- (소희님이 작성하신 파일들의 레이아웃도 제가 수정해보려 하였으나... 괜히 건들면 틀이 망가질까 싶어 일단 가만히 두었습니다.) 제 경우에는 title에 padding-top을 90px 정도 줄여놓았으니, 소희님도 해당 부분만 공통적으로 수정하여 화면 윗단과 실제 컴포넌트 공백을 줄이시면 될 것 같습니다!


## 👀 Screenshot / GIF / Link
-----
![image](https://github.com/webtoon-erp/front/assets/107592904/2661be1f-4f21-4fb5-a070-156a5f3bbaba)
![image](https://github.com/webtoon-erp/front/assets/107592904/cb98d67a-9e52-4430-9b87-edd21542c322)
